### PR TITLE
add reflection docu

### DIFF
--- a/src/main/java/com/intrafind/log4shell/Log4shellUpdate.java
+++ b/src/main/java/com/intrafind/log4shell/Log4shellUpdate.java
@@ -96,7 +96,7 @@ public class Log4shellUpdate {
     options.addOption("d", "dry-run", false, "only print replacements, do not replace files");
     options.addOption("h", "help", false, "print this help");
     options.addOption("b", "delete-backups", false, "delete backups automatically");
-    options.addOption("a", "allow-duplicates", false, "allow duplicate entries in zip files (will use reflection)");
+    options.addOption("a", "allow-duplicates", false, "allow duplicate entries in zip files\n----\nwill use reflection\nyou might need to add\n--add-opens java.base/java.util.zip=ALL-UNNAMED");
     CommandLineParser parser = new DefaultParser();
 
     try {


### PR DESCRIPTION
$ java -jar target/if-log4shell-updater-1.5.0-SNAPSHOT-jar-with-dependencies.jar
Missing required option: p
usage: if-log4shell-updater
 -a,--allow-duplicates   allow duplicate entries in zip files
                         ----
                         will use reflection
                         you might need to add
                         --add-opens java.base/java.util.zip=ALL-UNNAMED
 -b,--delete-backups     delete backups automatically
 -d,--dry-run            only print replacements, do not replace files
 -h,--help               print this help
 -p,--path <arg>         path to iFinder service